### PR TITLE
Make tests run with default `mops test` invocation

### DIFF
--- a/src/ecdsa/Der.mo
+++ b/src/ecdsa/Der.mo
@@ -179,7 +179,7 @@ module {
       // Align to 32 bytes.
       let aligned : [var Nat8] = Array.init<Nat8>(32, 0);
       for (i in Iter.range(0, Nat.min(rData.size() - 1, 31))) {
-        aligned[aligned.size() - 1 - i] := rData[rData.size() - 1 -i];
+        aligned[aligned.size() - 1 - i] := rData[rData.size() - 1 - i];
       };
       Array.freeze(aligned);
     } else {
@@ -190,7 +190,7 @@ module {
       // Align to 32 bytes.
       let aligned : [var Nat8] = Array.init<Nat8>(32, 0);
       for (i in Iter.range(0, Nat.min(sData.size() - 1, 31))) {
-        aligned[aligned.size() - 1 - i] := sData[sData.size() - 1 -i];
+        aligned[aligned.size() - 1 - i] := sData[sData.size() - 1 - i];
       };
       Array.freeze(aligned);
     } else {

--- a/test/Hex.mo
+++ b/test/Hex.mo
@@ -64,7 +64,7 @@ module {
       switch (decodeChar(cs[j])) {
         case (#err(e)) { return #err(e) };
         case (#ok(x0)) {
-          switch (decodeChar(cs[j +1])) {
+          switch (decodeChar(cs[j + 1])) {
             case (#err(e)) { return #err(e) };
             case (#ok(x1)) {
               ns[i] := x0 * base + x1;

--- a/test/bip32.test.mo
+++ b/test/bip32.test.mo
@@ -1,3 +1,5 @@
+// @testmode wasi
+
 import Bip32 "../src/Bip32";
 import Iter "mo:base/Iter";
 import { test } "mo:test";

--- a/test/bitcoin/p2pkhSighash.test.mo
+++ b/test/bitcoin/p2pkhSighash.test.mo
@@ -1,3 +1,5 @@
+// @testmode wasi
+
 import Debug "mo:base/Debug";
 import Array "mo:base/Array";
 import Int32 "mo:base/Int32";

--- a/test/ec/jacobi.test.mo
+++ b/test/ec/jacobi.test.mo
@@ -109,7 +109,7 @@ func testWycheproofEcdh(testCase : WycheproofEcdhTestCase) {
       // expects a 32-byte array.
       let alignedPrivateKey = Array.init<Nat8>(32, 0);
       for (i in Iter.range(0, Nat.min(privateKeyBytes.size() - 1, 31))) {
-        alignedPrivateKey[alignedPrivateKey.size() - 1 - i] := privateKeyBytes[privateKeyBytes.size() - 1 -i];
+        alignedPrivateKey[alignedPrivateKey.size() - 1 - i] := privateKeyBytes[privateKeyBytes.size() - 1 - i];
       };
       let privateKey : Nat = Common.readBE256(Array.freeze(alignedPrivateKey), 0);
 

--- a/test/ecdsa/ecdsa.test.mo
+++ b/test/ecdsa/ecdsa.test.mo
@@ -1,3 +1,5 @@
+// @testmode wasi
+
 import PublicKey "../../src/ecdsa/Publickey";
 import WycheproofEcdsaTestVectors "./wycheproofEcdsaSecp256k1TestVectors";
 import Hex "../Hex";


### PR DESCRIPTION
3 tests run only with `--mode wasi` (for reasons I don't currently understand). This PR adds a comment to each test that changes the default mode to `wasi`.