### PR TITLE
fix: rename Network variants to lowercase

### DIFF
--- a/src/bitcoin/P2pkh.mo
+++ b/src/bitcoin/P2pkh.mo
@@ -58,10 +58,10 @@ module {
   // Map given network to its id.
   func encodeVersion(network : Types.Network) : Nat8 {
     switch (network) {
-      case (#Mainnet) {
+      case (#mainnet) {
         0x00;
       };
-      case (#Regtest or #Testnet) {
+      case (#regtest or #testnet) {
         0x6f;
       };
     };
@@ -118,10 +118,10 @@ module {
 
     return switch (decoded.next(), ByteUtils.read(decoded, 20, false)) {
       case (?(0x00), ?publicKeyHash) {
-        #ok { network = #Mainnet; publicKeyHash = publicKeyHash };
+        #ok { network = #mainnet; publicKeyHash = publicKeyHash };
       };
       case (?(0x6f), ?publicKeyHash) {
-        #ok { network = #Testnet; publicKeyHash = publicKeyHash };
+        #ok { network = #testnet; publicKeyHash = publicKeyHash };
       };
       case (?(_networkId), ?_) {
         #err("Unrecognized network id.");

--- a/src/bitcoin/Types.mo
+++ b/src/bitcoin/Types.mo
@@ -12,9 +12,9 @@ module {
   // The type of Bitcoin network.
   /// Supported Bitcoin networks.
   public type Network = {
-    #Mainnet;
-    #Regtest;
-    #Testnet;
+    #mainnet;
+    #regtest;
+    #testnet;
   };
 
   // A reference to a transaction output.

--- a/src/bitcoin/Wif.mo
+++ b/src/bitcoin/Wif.mo
@@ -24,10 +24,10 @@ module {
   // Map network to WIF version prefix.
   func _encodeVersion(network : Types.Network) : Nat8 {
     switch (network) {
-      case (#Mainnet) {
+      case (#mainnet) {
         0x80;
       };
-      case (#Regtest or #Testnet) {
+      case (#regtest or #testnet) {
         0xef;
       };
     };
@@ -37,10 +37,10 @@ module {
   func decodeVersion(version : Nat8) : ?Types.Network {
     switch (version) {
       case (0x80) {
-        ?(#Mainnet);
+        ?(#mainnet);
       };
       case (0xef) {
-        ?(#Testnet);
+        ?(#testnet);
       };
       case _ {
         null;

--- a/test/bitcoin/p2pkh.test.mo
+++ b/test/bitcoin/p2pkh.test.mo
@@ -27,7 +27,7 @@ let addressTestData : [AddressTestCase] = [
       0x8a, 0x04, 0x5f, 0xa6, 0x42, 0xb9, 0x9e, 0xa5, 0xd1
     ];
     p2pkh = "1MmqjDhakEfJd9r5BoDhPApCpA75Em17GA";
-    network = #Mainnet;
+    network = #mainnet;
   },
 ];
 

--- a/test/bitcoin/p2pkhTransaction.test.mo
+++ b/test/bitcoin/p2pkhTransaction.test.mo
@@ -52,7 +52,7 @@ func makeTransaction(testCase : TransactionTestCase) : Transaction.Transaction {
     func(output : TxOutput) {
       switch (
         P2pkh.makeScript(
-          P2pkh.deriveAddress(#Mainnet, (output.publicKey, Curves.secp256k1))
+          P2pkh.deriveAddress(#mainnet, (output.publicKey, Curves.secp256k1))
         )
       ) {
         case (#ok script) {


### PR DESCRIPTION
Closes #22

Change `Network` type from PascalCase (`#Mainnet`, `#Testnet`, `#Regtest`) to lowercase (`#mainnet`, `#testnet`, `#regtest`), consistent with:
- IC management canister Bitcoin API (`{ mainnet; testnet }`)
- General Motoko convention (lowercase variant tags)

This eliminates the need for a conversion function when bridging between `mo:bitcoin` and the IC management canister Bitcoin API.

**Breaking change**: callers using the old PascalCase variants need to update to lowercase.